### PR TITLE
ci: raise two actions GitHub no longer runs

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
`actionlint` on this workflow:

```
the runner of "actions/checkout@v3" action is too old to run on GitHub Actions
the runner of "actions/setup-python@v3" action is too old to run on GitHub Actions
```

This lane only fires on a tag and has never run, so nothing is broken today — but the next release would have been the moment to discover it.

Raised to the versions the rest of the fleet uses: `checkout@v7` (2263 other workflows) and `setup-python@v7` (387). The `pypa/gh-action-pypi-publish` pin is a commit SHA and is deliberately left alone — pinning a publishing step by digest is the right thing.

Found by running `actionlint` across every repository in the fleet that has workflows (1131 of them, 1281 files); this was one of six repositories it flagged, and the only Python one we own.